### PR TITLE
feat: sync database types with TypeScript definitions

### DIFF
--- a/database/migrations/002_sync_types_with_typescript.pgsql
+++ b/database/migrations/002_sync_types_with_typescript.pgsql
@@ -1,0 +1,41 @@
+--postgresql
+-- Update types to match TypeScript definitions
+
+-- Update the manufacturer enum to add Reylight and fix Sofirn spelling
+BEGIN;
+
+-- Step 1: Rename existing type to temporary
+ALTER TYPE manufacturer RENAME TO manufacturer_old;
+
+-- Step 2: Create new type with correct values matching TypeScript
+CREATE TYPE manufacturer AS ENUM (
+  'Acebeam', 'Wurkkos', 'Sofrin', 'Skilhunt', 
+  'Olight', 'Nitecore', 'Convoy', 'Emisar', 'Fireflies', 'Reylight'
+);
+
+-- Step 3: Update the table to use new type, converting Sofirn to Sofrin
+ALTER TABLE flashlights 
+  ALTER COLUMN manufacturer TYPE manufacturer 
+  USING CASE 
+    WHEN manufacturer::text = 'Sofirn' THEN 'Sofrin'::manufacturer
+    ELSE manufacturer::text::manufacturer
+  END;
+
+-- Step 4: Drop the old type
+DROP TYPE manufacturer_old;
+
+COMMIT;
+
+-- Add missing finish group values that are in TypeScript but not in database
+ALTER TYPE finish_group ADD VALUE IF NOT EXISTS 'Stainless Steel';
+ALTER TYPE finish_group ADD VALUE IF NOT EXISTS 'Brass';
+
+-- Add table comments to document the TypeScript interfaces
+COMMENT ON TABLE flashlights IS 'Main flashlight table - corresponds to Flashlight interface';
+COMMENT ON TABLE emitters IS 'Emitter details - corresponds to Emitter interface';
+COMMENT ON TABLE user_preferences IS 'User preferences - corresponds to UserPreferences interface';
+COMMENT ON TABLE flashlight_manuals IS 'Flashlight manuals with embeddings - corresponds to FlashlightManual interface';
+
+-- Add column comments to clarify nullable fields
+COMMENT ON COLUMN flashlights.notes IS 'Optional notes about the flashlight';
+COMMENT ON COLUMN emitters.cct IS 'Color temperature - null for non-white emitters';

--- a/src/types/flashlight.ts
+++ b/src/types/flashlight.ts
@@ -50,11 +50,22 @@ export enum EmitterColor {
   LASER_RED = "Red Laser",
 }
 
+export enum FlashlightStatus {
+  NEW = "New",
+  ACTIVE = "Active",
+  STORAGE = "Storage",
+  GIFTED = "Gifted",
+  RETIRED = "Retired",
+}
+
 export interface Emitter {
+  id?: string;
+  flashlight_id?: string;
   type: string;
   cct: string | null; // Can be null for non-white emitters
   count: number;
   color: EmitterColor; // Defaults to WHITE if not specified
+  created_at?: string;
 }
 
 export enum FormFactor {
@@ -83,11 +94,13 @@ export enum IPRating {
 }
 
 export interface Flashlight {
+  id?: string;
+  user_id?: string;
   model: string;
   manufacturer: Manufacturer;
   finish: string;
   finish_group: FinishGroup;
-  battery_type: BatteryType; // Updated to use enum
+  battery_type: BatteryType;
   emitters: Emitter[];
   driver: string;
   ui: string;
@@ -95,8 +108,31 @@ export interface Flashlight {
   form_factors: FormFactor[];
   ip_rating?: IPRating;
   special_features: string[];
-  notes: string;
+  notes?: string;
   purchase_date: string;
   shipping_status: ShippingStatus;
-  status: "New" | "Active" | "Storage" | "Gifted" | "Retired";
+  status: FlashlightStatus;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface UserPreferences {
+  user_id: string;
+  preferred_cct_min?: number;
+  preferred_cct_max?: number;
+  preferred_battery_types?: string[];
+  preferred_manufacturers?: string[];
+  preferred_form_factors?: string[];
+  preferred_features?: string[];
+  updated_at?: string;
+}
+
+export interface FlashlightManual {
+  id?: string;
+  flashlight_id: string;
+  title: string;
+  content?: string;
+  file_path?: string;
+  embedding?: number[];
+  created_at?: string;
 }


### PR DESCRIPTION
## Summary
- Add REYLIGHT manufacturer that was missing from the database
- Update Sofirn spelling to Sofrin to match TypeScript definitions  
- Add missing finish group values (Stainless Steel, Brass)
- Add documentation comments to map database tables to TypeScript interfaces

## Test plan
- [x] Run migration script in Supabase
- [x] Verify existing data migrates correctly
- [x] Test creating new flashlights with updated types

🤖 Generated with [Claude Code](https://claude.ai/code)